### PR TITLE
TIS-84: add sequence diagram for aggregate database publishing basics

### DIFF
--- a/architecture/tis/validation/seq_publish_process.puml
+++ b/architecture/tis/validation/seq_publish_process.puml
@@ -1,0 +1,22 @@
+@startuml
+'https://plantuml.com/sequence-diagram
+!theme fintraffic_c4 from ../layout
+
+autonumber
+
+queue  VacoPublish as "VACO Jobs / Publish"
+control QueueListener
+control Publisher
+database AggregateDB as "Aggregate\nDatabase"
+database EntryDB as "Queue Entry\nDatabase"
+
+VacoPublish -> QueueListener: next queue entry
+QueueListener -> Publisher: entry and job metadata
+Publisher -> Publisher: check job is ready to publish
+Publisher -> AggregateDB: publish job artifacts and metadata
+Publisher <-- AggregateDB: acknowledge publishing
+Publisher -> EntryDB: record publishing result
+QueueListener <-- Publisher: publishing result
+VacoPublish <-- QueueListener: acknowledge entry
+
+@enduml


### PR DESCRIPTION
This is very handwavey at the moment since we do not have any information available on specifics of aggdb.

As picture:
![seq_publish_process](https://github.com/tmfg/digitraffic-tis-utilities/assets/1393900/43fad594-4746-404e-8804-f072baeb9c6f)
