### PR TITLE
rename Maven projects to match actual contents

### DIFF
--- a/ecs-tasks/gbfs-entur/pom.xml
+++ b/ecs-tasks/gbfs-entur/pom.xml
@@ -8,7 +8,7 @@
     <version>${gbfs.validator.version}</version>
     <packaging>jar</packaging>
 
-    <name>Digitraffic TIS / VACO / Entur GBFS Nordic Validator</name>
+    <name>Digitraffic TIS / VACO / Entur GBFS Validator</name>
     <description>Maven wrapper for downloading Entur GBFS Validator and all of its dependencies for further packaging into a container with the Dockerfile present in this directory.</description>
     <inceptionYear>2024</inceptionYear>
     <licenses>

--- a/ecs-tasks/netex-entur/pom.xml
+++ b/ecs-tasks/netex-entur/pom.xml
@@ -8,7 +8,7 @@
     <version>1.0.1</version>
     <packaging>jar</packaging>
 
-    <name>Digitraffic TIS / VACO / Entur GBFS Nordic Validator</name>
+    <name>Digitraffic TIS / VACO / Entur NeTEx Nordic Validator</name>
     <description>Maven wrapper for downloading Entur NeTEx Nordic Validator 1.0.1 and all of its dependencies for further packaging into a container with the Dockerfile present in this directory.</description>
     <inceptionYear>2023</inceptionYear>
     <licenses>


### PR DESCRIPTION
I could blame copy-paste mistake for these, but that wouldn't make sense - the names were way too mangled.