### PR TITLE
TIS-658/update MobilityData/gtfs-validator to 5.0.1

### DIFF
--- a/ecs-tasks/gtfs-canonical/Dockerfile
+++ b/ecs-tasks/gtfs-canonical/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:bookworm-slim
 COPY --from=python:3.11-slim-bookworm / /
 COPY --from=openjdk:21-slim-bookworm / /
-COPY --from=ghcr.io/mobilitydata/gtfs-validator:4.2.0 /gtfs-validator-cli.jar /gtfs-validator-cli.jar
+COPY --from=ghcr.io/mobilitydata/gtfs-validator:5.0.1 /gtfs-validator-cli.jar /gtfs-validator-cli.jar
 
 ### copy of ENVs from merged images
 # python:3.11-slim-bullseye


### PR DESCRIPTION
Turns out that the two breaking changes the validator has have no impact on us, so updating is really easy.