### PR TITLE
update gbfs.entur version in Dockerfile

### DIFF
--- a/ecs-tasks/gbfs-entur/Dockerfile
+++ b/ecs-tasks/gbfs-entur/Dockerfile
@@ -5,7 +5,7 @@ RUN mvn package -DskipTests
 FROM debian:bookworm-slim
 COPY --from=python:3.11-slim-bookworm / /
 COPY --from=openjdk:21-slim-bookworm / /
-COPY --from=build /target/validation-gbfs-entur-2.0.7-jar-with-dependencies.jar /validation-gbfs-entur.jar
+COPY --from=build /target/validation-gbfs-entur-2.0.9-jar-with-dependencies.jar /validation-gbfs-entur.jar
 
 ### copy of ENVs from merged images
 # python:3.11-slim-bookworm


### PR DESCRIPTION
dependabot doesn't update this, should probably parameterize/generalize this away to avoid build breakage